### PR TITLE
Add jaxb-api 2.1 license as CDDL 1.1

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -14,3 +14,5 @@ org.hdrhistogram--HdrHistogram--2.1.9=BSD-2-Clause
 org.latencyutils--LatencyUtils--2.0.3=BSD-2-Clause
 # https://web.archive.org/web/20190614191124/http://www.extreme.indiana.edu/dist/java-repository/xpp3/licenses/LICENSE.txt
 xpp3--xpp3--1.1.3.4.O=BSD Variant (License for the Extreme! Lab)
+# https://javaee.github.io/jaxb-v2/LICENSE
+javax.xml.bind--jaxb-api--2.1=CDDL 1.1


### PR DESCRIPTION
JAXB is licensed under a dual license - CDDL 1.1 and GPL 2.0 with Class-path Exception. That means you can choose which one of the two suits your needs better and use it under those terms.