### PR TITLE
ACS-2303 License updates for acs-packaging.

### DIFF
--- a/includedLicenses.txt
+++ b/includedLicenses.txt
@@ -2,6 +2,7 @@ ANTLR-PD
 Apache-2.0
 BSD-2-Clause
 BSD-3-Clause
+BSD-3-Clause-No-Nuclear-Warranty
 CC0-1.0
 CDDL-1.0
 CDDL-1.1

--- a/licenseMerges.txt
+++ b/licenseMerges.txt
@@ -1,8 +1,9 @@
 Apache-2.0|Apache 2.0|The Apache Software License, Version 2.0|Apache License, Version 2.0|Apache License, version 2.0|Apache Public License 2.0|The Apache License, Version 2.0|Apache License 2.0|Apache 2|Apache Software License - Version 2.0|Apache License Version 2.0|Apache v2|Apache License v2|Apache License v2.0|ASF 2.0
 BSD-2-Clause|BSD-2
 BSD-3-Clause|BSD-3|3-Clause BSD License|HSQLDB License, a BSD open source license
+BSD-3-Clause-No-Nuclear-Warranty|BSD 3-Clause No Nuclear Warranty|BSD 3-clause License w/nuclear disclaimer
 CC0-1.0|CC0|Creative Commons License|Public Domain, per Creative Commons CC0
-CDDL-1.0|CDDL|Common Development and Distribution License|CDDL+GPL License|CDDL + GPLv2 with classpath exception
+CDDL-1.0|CDDL|Common Development and Distribution License|CDDL+GPL License|CDDL + GPLv2 with classpath exception|CDDL, v1.0
 CDDL-1.1|Common Development and Distribution License 1.1
 CPL-1.0|CPL|Common Public License
 EDL-1.0|EDL 1.0|Eclipse Distribution License, Version 1.0|Eclipse Distribution License - v1.0|Eclipse Distribution License - v 1.0
@@ -19,6 +20,6 @@ LGPL-3.0-or-later|GNU Lesser General Public License v3.0 or later|Lesser General
 MIT|The MIT License|MIT License|MIT license|MIT License (MIT)
 MPL-1.0|Mozilla Public License 1.0 (MPL 1.1)
 MPL-1.1|Mozilla Public License 1.1|Mozilla Public License 1.1 (MPL 1.1)
-MPL-2.0|Mozilla Public License 2.0
+MPL-2.0|Mozilla Public License 2.0|Mozilla Public License, Version 2.0
 PostgreSQL|PostgreSQL License
 Zlib|zlib License

--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -2,6 +2,8 @@
 antlr--antlr--2.7.7=ANTLR-PD
 # https://github.com/jgraph/jgraphx/blob/v3.9.10/license.txt
 com.github.jgraph--jgraphx--v3.9.10=BSD-3-Clause
+# https://github.com/virtuald/curvesapi/blob/1.06/license.txt
+com.github.virtuald--curvesapi--1.06=BSD-3-Clause
 # https://github.com/google/gdata-java-client/blob/master/COPYING
 com.google.gdata--gdata-core-1.0--1.47.1=Apache-2.0
 # https://github.com/google/gdata-java-client/blob/master/COPYING
@@ -16,14 +18,16 @@ commons-httpclient--commons-httpclient--3.1-HTTPCLIENT-1265=Apache-2.0
 de.schlichtherle.truelicense--truelicense--1_29-patched=Apache-2.0
 # https://artifacts.alfresco.com/nexus/content/repositories/public/de/schlichtherle/truelicense/truelicense/1_29-patched/truelicense-1_29-patched-sources.zip
 de.schlichtherle.truelicense--truelicense-xml--1_29-patched=Apache-2.0
+# https://github.com/unitsofmeasurement/unit-api/blob/1.0/LICENSE.txt
+javax.measure--unit-api--1.0=BSD-3-Clause
 # https://javaee.github.io/servlet-spec/LICENSE
 javax.servlet--javax.servlet-api--3.1.0=CDDL-1.1
 # https://javaee.github.io/jaxb-v2/LICENSE
 javax.xml.bind--jaxb-api--2.1=CDDL-1.1
 # https://github.com/jaxen-xpath/jaxen/blob/v1.2.0/LICENSE.txt
 jaxen--jaxen--1.2.0=BSD-3-Clause
-# https://github.com/stephenc/jcip-annotations/blob/master/LICENSE.txt
-net.jcip--jcip-annotations--1.0=Apache-2.0
+# https://jcip.net/
+net.jcip--jcip-annotations--1.0=CC-BY-2.5
 # https://code.google.com/archive/p/gwtwiki/
 net.sf--bliki--3.0.2=EPL-1.0
 # https://sourceforge.net/projects/jsr107cache/
@@ -44,8 +48,8 @@ org.codehaus.guessencoding--guessencoding--1.4=Apache-2.0
 org.codehaus.woodstox--stax2-api--3.1.4=BSD-2-Clause
 # https://github.com/dom4j/dom4j/blob/master/LICENSE
 org.dom4j--dom4j--2.1.3=BSD Variant (DOM4J License)
-# https://github.com/apache/freemarker/blob/2.3-gae/LICENSE
-org.freemarker--freemarker--2.3.20-alfresco-patched-20200421=Apache-2.0
+# https://github.com/freemarker/freemarker-old/blob/v2.3.20/LICENSE.txt
+org.freemarker--freemarker--2.3.20-alfresco-patched-20200421=BSD Variant (FreeMarker License)
 # https://github.com/HdrHistogram/HdrHistogram/blob/master/LICENSE.txt
 org.hdrhistogram--HdrHistogram--2.1.9=BSD-2-Clause
 # https://github.com/jboss-javassist/javassist/blob/rel_3_27_0_ga/License.html
@@ -60,6 +64,8 @@ org.ow2.asm--asm--5.1=BSD-3-Clause
 org.safehaus.jug--jug--2.0.0=Apache-2.0
 # https://github.com/qos-ch/slf4j/blob/v1.7.7/jcl-over-slf4j/LICENSE.txt
 org.slf4j--jcl-over-slf4j--1.7.7=Apache-2.0
+# https://github.com/tballison/jmatio/blob/master/LICENSE.txt
+org.tallison--jmatio--1.5=BSD-3-Clause
 # https://web.archive.org/web/20190614191124/http://www.extreme.indiana.edu/dist/java-repository/xpp3/licenses/LICENSE.txt
 xpp3--xpp3--1.1.3.4.O=BSD Variant (License for the Extreme! Lab)
 # https://web.archive.org/web/20190614191124/http://www.extreme.indiana.edu/dist/java-repository/xpp3/licenses/LICENSE.txt


### PR DESCRIPTION
There are more changes still required once we've done further investigation, but this part covers the bulk of the issues and looks fine to include now.