### PR TITLE
AAE-8898 - Allowed anltr4-runtime 4.9.3 and jolt-core 0.1.7

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -20,6 +20,8 @@ com.aspose--aspose-cells--21.9=Aspose EULA
 com.aspose--aspose-words--21.3=Aspose EULA
 # https://about.aspose.com/legal
 com.aspose--aspose-words--21.9=Aspose EULA
+# https://github.com/bazaarvoice/jolt/blob/jolt-0.1.7/LICENSE
+com.bazaarvoice.jolt--jolt-core--0.1.7=Apache-2.0
 # http://migbase64.sourceforge.net/
 com.brsanthu--migbase64--2.2=BSD-3-Clause
 # https://github.com/poetix/protonpack/blob/protonpack-1.13/LICENSE
@@ -146,6 +148,8 @@ org.antlr--antlr4-runtime--4.8-1=BSD-3-Clause
 org.antlr--antlr4-runtime--4.8=BSD-3-Clause
 # https://github.com/antlr/antlr4/blob/4.9.2/LICENSE.txt
 org.antlr--antlr4-runtime--4.9.2=BSD-3-Clause
+# https://github.com/antlr/antlr4/blob/4.9.3/LICENSE.txt
+org.antlr--antlr4-runtime--4.9.3=BSD-3-Clause
 # https://www.stringtemplate.org/license.html
 org.antlr--ST4--4.0.8=BSD-3-Clause
 # https://github.com/antlr/stringtemplate4/blob/4.3/LICENSE.txt


### PR DESCRIPTION
https://alfresco.atlassian.net/browse/AAE-8898

Needed for migrating to Spring Boot 2.7.0 and to use the JSON transformation library Jolt.

For the latter, we also opened a PR on the original library that, if approved, will avoid the need of adding this exception in the future: https://github.com/bazaarvoice/jolt/pull/1138
