### PR TITLE
ACS-2116 Add curvesapi 1.07

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -46,6 +46,8 @@ com.github.jai-imageio--jai-imageio-core--1.4.0=BSD-2-Clause
 com.github.jgraph--jgraphx--v3.9.10=BSD-3-Clause
 # https://github.com/virtuald/curvesapi/blob/1.06/license.txt
 com.github.virtuald--curvesapi--1.06=BSD-3-Clause
+# https://github.com/virtuald/curvesapi/blob/1.07/license.txt
+com.github.virtuald--curvesapi--1.07=BSD-3-Clause
 # https://github.com/vlsi/jgraphx-publish/blob/v4.1.0/LICENSE
 com.github.vlsi.mxgraph--jgraphx--4.1.0=BSD-3-Clause
 # https://github.com/vlsi/jgraphx-publish/blob/v4.2.2/LICENSE


### PR DESCRIPTION
Add license override for [curvesapi 1.07](https://github.com/virtuald/curvesapi/tree/1.07).
The lack of this license override causes https://app.travis-ci.com/github/Alfresco/alfresco-community-repo/jobs/573611105#L871-L873 which blocks https://github.com/Alfresco/alfresco-community-repo/pull/1028.