### PR TITLE
AAE-14223 - Enlist latest Antlr4

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -176,9 +176,9 @@ org.antlr--antlr-runtime--3.5.2=BSD-3-Clause
 org.antlr--antlr-runtime--3.5.3=BSD-3-Clause
 # https://www.antlr3.org/license.html
 org.antlr--antlr-runtime--3.5=BSD-3-Clause
-#https://github.com/antlr/antlr4/blob/4.10.1/LICENSE.txt
+# https://github.com/antlr/antlr4/blob/4.10.1/LICENSE.txt
 org.antlr--antlr4-runtime--4.10.1=BSD-3-Clause
-#https://github.com/antlr/antlr4/blob/4.12/LICENSE.txt
+# https://github.com/antlr/antlr4/blob/4.12/LICENSE.txt
 org.antlr--antlr4-runtime--4.12=BSD-3-Clause
 # https://github.com/antlr/antlr4/blob/4.7.2/LICENSE.txt
 org.antlr--antlr4-runtime--4.7.2=BSD-3-Clause

--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -176,6 +176,10 @@ org.antlr--antlr-runtime--3.5.2=BSD-3-Clause
 org.antlr--antlr-runtime--3.5.3=BSD-3-Clause
 # https://www.antlr3.org/license.html
 org.antlr--antlr-runtime--3.5=BSD-3-Clause
+#https://github.com/antlr/antlr4/blob/4.10.1/LICENSE.txt
+org.antlr--antlr4-runtime--4.10.1=BSD-3-Clause
+#https://github.com/antlr/antlr4/blob/4.12/LICENSE.txt
+org.antlr--antlr4-runtime--4.12=BSD-3-Clause
 # https://github.com/antlr/antlr4/blob/4.7.2/LICENSE.txt
 org.antlr--antlr4-runtime--4.7.2=BSD-3-Clause
 # https://www.antlr.org/license.html


### PR DESCRIPTION
Add Antlr4 runtime `4.10.1` (used by Spring Boot 3) and `4.12` for the next bump