### PR TITLE
ACS 4955 Add new JiBX version license

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -252,6 +252,8 @@ org.jboss.common--jboss-common-beans--2.0.1.Final=LGPL-2.1-only
 org.jboss.spec.javax.rmi--jboss-rmi-api_1.0_spec--1.0.6.Final=LGPL-2.1-only
 # http://jibx.sourceforge.net/jibx-license.html
 org.jibx--jibx-run--1.3.3=BSD-3-Clause
+# http://jibx.sourceforge.net/jibx-license.html
+org.jibx--jibx-run--1.4.2=BSD-3-Clause
 # https://github.com/jline/jline3/blob/jline-parent-3.4.0/LICENSE.txt
 org.jline--jline--3.4.0=BSD-3-Clause
 # https://github.com/jline/jline3/blob/jline-parent-3.4.0/LICENSE.txt


### PR DESCRIPTION
The new version of JiBX points to the same license as the old one from mvnrepository, and I can't find any info about the license changing, so if we want to bump JiBX version in community repo we need to make this change.