### PR TITLE
ACS-4955 Allow dom4j 2.1.4 Plexus license

### DIFF
--- a/includedLicenses.txt
+++ b/includedLicenses.txt
@@ -2,7 +2,6 @@ ANTLR-PD
 Apache Variant (JDOM License)
 Apache-2.0
 BSD Variant (dom4j License)
-Plexus (dom4j License)
 BSD Variant (FreeMarker License)
 BSD-2-Clause
 BSD-3-Clause
@@ -31,6 +30,7 @@ MIT-0
 MPL-1.0
 MPL-1.1
 MPL-2.0
+Plexus (dom4j License)
 PostgreSQL
 Public-Domain
 Unidata

--- a/includedLicenses.txt
+++ b/includedLicenses.txt
@@ -2,6 +2,7 @@ ANTLR-PD
 Apache Variant (JDOM License)
 Apache-2.0
 BSD Variant (dom4j License)
+Plexus (dom4j License)
 BSD Variant (FreeMarker License)
 BSD-2-Clause
 BSD-3-Clause

--- a/includedLicensesPlusAspose.txt
+++ b/includedLicensesPlusAspose.txt
@@ -3,7 +3,6 @@ Apache Variant (JDOM License)
 Apache-2.0
 Aspose EULA
 BSD Variant (dom4j License)
-Plexus (dom4j License)
 BSD Variant (FreeMarker License)
 BSD-2-Clause
 BSD-3-Clause
@@ -32,6 +31,7 @@ MIT-0
 MPL-1.0
 MPL-1.1
 MPL-2.0
+Plexus (dom4j License)
 PostgreSQL
 Public-Domain
 Unidata

--- a/includedLicensesPlusAspose.txt
+++ b/includedLicensesPlusAspose.txt
@@ -3,6 +3,7 @@ Apache Variant (JDOM License)
 Apache-2.0
 Aspose EULA
 BSD Variant (dom4j License)
+Plexus (dom4j License)
 BSD Variant (FreeMarker License)
 BSD-2-Clause
 BSD-3-Clause

--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -224,6 +224,8 @@ org.codehaus.woodstox--stax2-api--4.1=BSD-2-Clause
 org.codehaus.woodstox--stax2-api--4.2.1=BSD-2-Clause
 # https://github.com/dom4j/dom4j/blob/master/LICENSE
 org.dom4j--dom4j--2.1.3=BSD Variant (dom4j License)
+# https://github.com/dom4j/dom4j/blob/master/LICENSE
+org.dom4j--dom4j--2.1.4=Plexus (dom4j License)
 # https://github.com/freemarker/freemarker-old/blob/v2.3.20/LICENSE.txt
 org.freemarker--freemarker--2.3.20-alfresco-patched-20200421=BSD Variant (FreeMarker License)
 # https://github.com/freemarker/freemarker-old/blob/v2.3.20/LICENSE.txt


### PR DESCRIPTION
Allowing the dom4j 2.1.4 Plexus license, which was simply renamed from "BSD Variant" to "Plexus" without any actual license body changes.

This has been confirmed and approved via https://go.scoutrfp.com/planner/projects/2818319.