### PR TITLE
ACS-4955 Allow Plexus license

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Currently the project is designed to be used with the [license-maven-plugin](htt
 
 ---
 
+> ⚠ **NOTE:**
+> After updating this repository, give it a few minutes before re-running a build that was previously failing due to a forbidden or unknown license, as it takes some time for the raw GitHub files cache to be invalidated.
+
 # Licence allow list
 
 The `includeLicenses.txt` file is a centralized list of licences allowed for use in Alfresco software. The format
@@ -59,7 +62,7 @@ Example configuration for this will look like:
 
 ```
   <properties>
-    <license-maven-plugin.version>2.0.1</license-maven-plugin.version>
+    <license-maven-plugin.version>2.1.0</license-maven-plugin.version>
     ...
   </properties>
 ...

--- a/includedLicenses.txt
+++ b/includedLicenses.txt
@@ -30,7 +30,7 @@ MIT-0
 MPL-1.0
 MPL-1.1
 MPL-2.0
-Plexus (dom4j License)
+Plexus
 PostgreSQL
 Public-Domain
 Unidata

--- a/includedLicensesPlusAspose.txt
+++ b/includedLicensesPlusAspose.txt
@@ -31,7 +31,7 @@ MIT-0
 MPL-1.0
 MPL-1.1
 MPL-2.0
-Plexus (dom4j License)
+Plexus
 PostgreSQL
 Public-Domain
 Unidata

--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -224,8 +224,6 @@ org.codehaus.woodstox--stax2-api--4.1=BSD-2-Clause
 org.codehaus.woodstox--stax2-api--4.2.1=BSD-2-Clause
 # https://github.com/dom4j/dom4j/blob/master/LICENSE
 org.dom4j--dom4j--2.1.3=BSD Variant (dom4j License)
-# https://github.com/dom4j/dom4j/blob/master/LICENSE
-org.dom4j--dom4j--2.1.4=Plexus (dom4j License)
 # https://github.com/freemarker/freemarker-old/blob/v2.3.20/LICENSE.txt
 org.freemarker--freemarker--2.3.20-alfresco-patched-20200421=BSD Variant (FreeMarker License)
 # https://github.com/freemarker/freemarker-old/blob/v2.3.20/LICENSE.txt


### PR DESCRIPTION
I noticed that the dom4j Plexus license and a generic Plexus license are exactly the same, therefore we can allow the Plexus license in its entirety.

Including some minor README fix-ups as well.