### PR TITLE
ACS-6653 Add curvesapi 1.08

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -66,6 +66,8 @@ com.github.jgraph--jgraphx--v3.9.10=BSD-3-Clause
 com.github.virtuald--curvesapi--1.06=BSD-3-Clause
 # https://github.com/virtuald/curvesapi/blob/1.07/license.txt
 com.github.virtuald--curvesapi--1.07=BSD-3-Clause
+# https://github.com/virtuald/curvesapi/blob/1.08/license.txt
+com.github.virtuald--curvesapi--1.08=BSD-3-Clause
 # https://github.com/vlsi/jgraphx-publish/blob/v4.1.0/LICENSE
 com.github.vlsi.mxgraph--jgraphx--4.1.0=BSD-3-Clause
 # https://github.com/vlsi/jgraphx-publish/blob/v4.2.2/LICENSE


### PR DESCRIPTION
Add 3rd party license override for curvesapi 1.08, there were no license changes compared to the previous version: https://github.com/virtuald/curvesapi/tree/1.08.