### PR TITLE
Only run formatter once against all files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,5 @@ repos:
     entry: ./licenseProcessor.py
     language: python
     verbose: true
+    exclude: ''
+    always_run: true


### PR DESCRIPTION
Avoids running the formatter against each individual file, which caused issues if run in parallel.