### PR TITLE
Add new version of ST4 (4.3.4) with the same license

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -210,6 +210,8 @@ org.antlr--ST4--4.0.8=BSD-3-Clause
 org.antlr--ST4--4.3.1=BSD-3-Clause
 # https://github.com/antlr/stringtemplate4/blob/4.3/LICENSE.txt
 org.antlr--ST4--4.3=BSD-3-Clause
+# https://github.com/antlr/stringtemplate4/blob/ST4-4.3.4/LICENSE.txt
+org.antlr--ST4--4.3.4=BSD-3-Clause
 # https://www.stringtemplate.org/license.html
 org.antlr--stringtemplate--3.2.1=BSD-3-Clause
 # https://hc.apache.org/httpclient-legacy/license.html


### PR DESCRIPTION
The new version of ST4 (4.3.4) has the same license as the old one (4.3).