### PR TITLE
AAE-44724 Allow docusign-esign-java 6.6.0

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -72,6 +72,8 @@ com.docusign--docusign-esign-java--6.1.0=MIT
 com.docusign--docusign-esign-java--6.4.0=MIT
 # https://github.com/docusign/docusign-esign-java-client/blob/v6.5.0/LICENSE
 com.docusign--docusign-esign-java--6.5.0=MIT
+# https://github.com/docusign/docusign-esign-java-client/blob/v6.6.0/LICENSE
+com.docusign--docusign-esign-java--6.6.0=MIT
 # https://github.com/forcedotcom/wsc/blob/51.2.0/LICENSE.md
 com.force.api--force-wsc--51.2.0=BSD-3-Clause
 # https://github.com/forcedotcom/wsc/blob/58.0.0/LICENSE.md


### PR DESCRIPTION
License did not change compared to previously approved version.