### PR TITLE
AAE-45108 Allow force-wsc 67.0.0

### DIFF
--- a/override-THIRD-PARTY.properties
+++ b/override-THIRD-PARTY.properties
@@ -80,14 +80,16 @@ com.force.api--force-wsc--51.2.0=BSD-3-Clause
 com.force.api--force-wsc--58.0.0=BSD-3-Clause
 # https://github.com/forcedotcom/wsc/blob/62.0.0/LICENSE.md
 com.force.api--force-wsc--62.0.0=BSD-3-Clause
-# https://github.com/forcedotcom/wsc/blob/64.0.0/LICENSE.md
+# https://github.com/forcedotcom/wsc/blob/master/LICENSE.md
 com.force.api--force-wsc--64.0.2=BSD-3-Clause
-# https://github.com/forcedotcom/wsc/blob/64.0.0/LICENSE.md
+# https://github.com/forcedotcom/wsc/blob/master/LICENSE.md
 com.force.api--force-wsc--64.0.3=BSD-3-Clause
-# https://github.com/forcedotcom/wsc/blob/65.0.0/LICENSE.md
+# https://github.com/forcedotcom/wsc/blob/master/LICENSE.md
 com.force.api--force-wsc--65.0.0=BSD-3-Clause
-# https://github.com/forcedotcom/wsc/blob/66.0.0/LICENSE.md
+# https://github.com/forcedotcom/wsc/blob/master/LICENSE.md
 com.force.api--force-wsc--66.0.0=BSD-3-Clause
+# https://github.com/forcedotcom/wsc/blob/master/LICENSE.md
+com.force.api--force-wsc--67.0.0=BSD-3-Clause
 # https://github.com/jai-imageio/jai-imageio-core/blob/jai-imageio-core-1.4.0/LICENSE.txt
 com.github.jai-imageio--jai-imageio-core--1.4.0=BSD-2-Clause
 # https://github.com/jgraph/jgraphx/blob/v3.9.10/license.txt


### PR DESCRIPTION
As per title, also adapting broken links to point to master.

Created an issue to keep track of the fact that wsc is not pushing git tags anymore for latest releases: https://github.com/forcedotcom/wsc/issues/369